### PR TITLE
meson.build: meson_options.txt: add build option to disable building tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -855,7 +855,8 @@ libxserver += libxserver_dri3
 
 subdir('hw')
 
-if host_machine.system() != 'windows'
+build_tests = get_option('tests') and host_machine.system() != 'windows'
+if build_tests
     subdir('test')
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -115,6 +115,8 @@ option('sha1', type: 'combo', choices: ['libc', 'CommonCrypto', 'CryptoAPI', 'li
        description: 'SHA1 implementation')
 option('xf86-input-inputtest', type: 'boolean', value: true,
        description: 'Test input driver support on Xorg')
+option('tests', type: 'boolean', value: true,
+       description: 'Build tests for the X server on platforms that support it')
 
 option('dri1', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto', description: 'Build DRI1 extension (default: auto)')
 option('dri2', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto', description: 'Build DRI2 extension (default: auto)')


### PR DESCRIPTION
These tests take a long time to build and link, especially with lto.