### PR TITLE
dix: Silence a compiler warning in doListFontsWithInfo()

### DIFF
--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -848,7 +848,7 @@ doListFontsWithInfo(ClientPtr client, LFWIclosurePtr c)
 {
     FontPathElementPtr fpe;
     int err = Successful;
-    char *name;
+    char *name = NULL;
     int namelen = 0;
     int numFonts;
     FontInfoRec fontInfo, *pFontInfo;
@@ -912,6 +912,10 @@ doListFontsWithInfo(ClientPtr client, LFWIclosurePtr c)
              * is BadFontName, indicating the alias resolution
              * is complete.
              */
+            if (!name) {
+                err = BadFontName;
+                goto ContBadFontName;
+            }
             if (c->haveSaved) {
                 char *tmpname;
                 int tmpnamelen;


### PR DESCRIPTION
Static analyzer reports:

| dix/dixfonts.c:936:17: uninit_use_in_call: Using uninitialized value "name" when calling "memcpy".
|   934|                   free(c->savedName);
|   935|                   c->savedName = XNFalloc(namelen + 1);
|   936|->                 memcpy(c->savedName, name, namelen + 1);
|   937|                   aliascount = 20;
|   938|               }

To silence the warning, we cannot just set "name" to NULL, as this could potentially cause a NULL pointer in memcpy(), we also need to check if the value was set. If not, just bail out with a BadFontNAme error.


Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2238>